### PR TITLE
allow for ruby version that do not include a path level

### DIFF
--- a/definitions/ruby.rb
+++ b/definitions/ruby.rb
@@ -2,7 +2,7 @@ define :build_ruby, :version => nil, :patchlevel => nil, :repository => nil do
 
   r_version = params[:version]
   r_patchlevel = params[:patchlevel]
-  r_fullversion = r_patchlevel.nil? ? params[:version] : [params[:version], params[:patchlevel]].join('-')
+  r_fullversion = [params[:version], params[:patchlevel]].compact.join('-')
 
   include_recipe 'pkg-build::deps'
 

--- a/libraries/ruby.rb
+++ b/libraries/ruby.rb
@@ -20,12 +20,10 @@ module PkgBuild
       end
 
       def ruby_build(node, version, patchlevel)
-        if patchlevel.nil?
-          patch = ''
-        else
+        if (patchlevel)
           patch = patchlevel.to_s.start_with?('p') ? patchlevel : "p#{patchlevel}"
         end
-        "#{ruby_name(node, version)}-#{version}-#{patch}"
+        [ruby_name(node, version), version, patch].compact.join('-')
       end
     end
   end

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -9,10 +9,10 @@ comparable_versions = []
 
 versions.uniq.each do |r_ver|
   version, patchlevel = r_ver.split('-')
-  comparable_versions << [Gem::Version.new(version), patchlevel.nil? ? nil : patchlevel[1,patchlevel.length].to_i]
+  comparable_versions << [Gem::Version.new(version), patchlevel.nil? ? nil : patchlevel.to_s[1,patchlevel.length].to_i]
 
   if(node[:pkg_build][:isolate])
-    pkg_build_isolate patchlevel.nil? ? "ruby-#{version}" : "ruby-#{version}-#{patchlevel}" do
+    pkg_build_isolate ['ruby', version, patchlevel].compact.join('-') do
       container 'ubuntu_1204'
       attributes(
         :pkg_build => {


### PR DESCRIPTION
This is to support building ruby packages that do not include a patch level. For example.. Ruby 2.1.0 release. Pushing upstream from Ninefold.
